### PR TITLE
Allow to pass metadata and operation to ES Sink

### DIFF
--- a/examples/bspump-es-sink-upsert.py
+++ b/examples/bspump-es-sink-upsert.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+import hashlib
+import logging
+
+import bspump
+import bspump.common
+import bspump.elasticsearch
+import bspump.file
+import bspump.trigger
+from bspump import Processor
+
+###
+
+L = logging.getLogger(__name__)
+
+###
+
+
+class GenerateIdProcessor(Processor):
+
+	def process(self, context, event):
+		context["elasticsearch_operation_metadata"] = {
+			"_id": hashlib.sha1(event.get("name").encode('utf-8')).hexdigest(),  # name will be unique in target index
+			"_index": "override_custom_index"
+		}
+
+		context["elasticsearch_doc_metadata"] = {
+			"doc_as_upsert": True
+		}
+
+		context["elasticsearch_operation"] = "update"
+
+		return event
+
+
+class SamplePipeline(bspump.Pipeline):
+
+	def __init__(self, app, pipeline_id):
+		super().__init__(app, pipeline_id)
+		self.build(
+			bspump.file.FileLineSource(app, self, config={
+				'path': './data/es_sink_upsert.txt',
+				'post': 'noop',
+			}).on(bspump.trigger.RunOnceTrigger(app)),
+
+			bspump.common.JsonBytesToDictParser(app, self),
+			GenerateIdProcessor(app, self),
+			bspump.elasticsearch.ElasticSearchSink(app, self, "ESConnection")
+		)
+
+
+if __name__ == '__main__':
+	app = bspump.BSPumpApplication()
+
+	svc = app.get_service("bspump.PumpService")
+
+	svc.add_connection(
+		bspump.elasticsearch.ElasticSearchConnection(app, "ESConnection", config={
+			"bulk_out_max_size": 100
+		}))
+
+	# Construct and register Pipeline
+	pl = SamplePipeline(app, 'SamplePipeline')
+	svc.add_pipeline(pl)
+
+	app.run()

--- a/examples/data/es_sink_upsert.txt
+++ b/examples/data/es_sink_upsert.txt
@@ -1,0 +1,5 @@
+{ "name" : "John Wick"}
+{ "name" : "Chuck Norris" }
+{ "name" : "John Wick" }
+{ "name" : "Chuck Norris" }
+{ "name" : "Chuck Norris" }

--- a/test/elasticsearch/test_elasticsearchsink.py
+++ b/test/elasticsearch/test_elasticsearchsink.py
@@ -35,7 +35,7 @@ class TestElasticSearchSink(bspump.unittest.ProcessorTestCase):
 			connection="ESConnection",
 			config={
 				"index_prefix": "not_existing_pattern_",
-				"rollover_mechanism": "fixed",
+				"rollover_mechanism": "noop",
 			}
 		)
 
@@ -49,9 +49,69 @@ class TestElasticSearchSink(bspump.unittest.ProcessorTestCase):
 		for request_id, request_content in mocked.requests.items():
 			request_count += 1
 			url = str(request_id[1])
-			assert url == "http://non-existing-url:9200/_bulk"
-			assert request_content[0].kwargs["data"] == \
-				'{{"index": {{ "_index": "not_existing_pattern_", "_type": "doc" }}\n{}\n'.format(expected_output_json)
-		assert request_count == 1
+			self.assertEqual("http://non-existing-url:9200/_bulk", url)
+			self.assertEqual(
+				'{{"index": {{"_index": "not_existing_pattern_", "_type": "doc"}}}}\n{{"doc": {}}}\n'.format(
+					expected_output_json),
+				request_content[0].kwargs["data"]
+			)
+		self.assertEqual(1, request_count)
+
+		self.assertEqual(output, [])
+
+	@aioresponses()
+	def test_elasticsearch_sink_upsert(self, mocked):
+		mocked.post(
+			"http://non-existing-url:9200/_bulk",
+			body='{"items": []}',
+			status=200
+		)
+
+		svc = self.App.get_service("bspump.PumpService")
+		svc.add_connection(
+			bspump.elasticsearch.ElasticSearchConnection(
+				self.App,
+				"ESConnection",
+				config={
+					"bulk_out_max_size": 1,
+					"url": "http://non-existing-url:9200/",
+				}
+			)
+		)
+
+		events = [
+			(
+				{
+					"elasticsearch_operation_metadata": {"_id": "my_id", "_index": "override_index"},
+					"elasticsearch_doc_metadata": {"doc_as_upsert": True}
+				},
+				{"hello-field": "no-important-data-here"}
+			)
+		]
+
+		self.set_up_processor(
+			bspump.elasticsearch.ElasticSearchSink,
+			connection="ESConnection",
+			config={
+				"index_prefix": "not_existing_pattern_",
+				"rollover_mechanism": "noop",
+			}
+		)
+
+		output = self.execute(
+			events
+		)
+
+		request_count = 0
+		for request_id, request_content in mocked.requests.items():
+			request_count += 1
+			url = str(request_id[1])
+			self.assertEqual("http://non-existing-url:9200/_bulk", url)
+			self.assertEqual(
+				'{"index": {"_index": "override_index", "_type": "doc", "_id": "my_id"}}\n'
+				'{"doc": {"hello-field": "no-important-data-here"}, "doc_as_upsert": true}\n',
+				request_content[0].kwargs["data"]
+			)
+		self.assertEqual(1, request_count)
 
 		self.assertEqual(output, [])


### PR DESCRIPTION
Added new context attributes:

- **elasticsearch_doc_metadata**: Additional parameters on doc level (E.g. doc_as_upsert, ...)
- **elasticsearch_operation_metadata**: Additional parameters on operation level (E.g. _id, _index, ...)
- **elasticsearch_operation**: Custom operation (E.g. update, script, ...). Default is "index"

closes #60