### PR TITLE
Add configuration for Kafka SASL

### DIFF
--- a/bspump/kafka/connection.py
+++ b/bspump/kafka/connection.py
@@ -30,14 +30,26 @@ class KafkaConnection(Connection):
 
 	``ConfigDefaults`` options:
 
-		* ``compression_type``: Kafka supports several compression types: ``gzip``, ``snappy`` and ``lz4``.
+		compression_type (str): Kafka supports several compression types: ``gzip``, ``snappy`` and ``lz4``.
 			This option needs to be specified in Kafka Producer only, Consumer will decompress automatically.
-
+		security_protocol (str): Protocol used to communicate with brokers.
+			Valid values are: PLAINTEXT, SSL. Default: PLAINTEXT.
+		sasl_mechanism (str): Authentication mechanism when security_protocol
+			is configured for SASL_PLAINTEXT or SASL_SSL. Valid values are:
+			PLAIN, GSSAPI, SCRAM-SHA-256, SCRAM-SHA-512. Default: PLAIN
+		sasl_plain_username (str): username for sasl PLAIN authentication.
+			Default: None
+		sasl_plain_password (str): password for sasl PLAIN authentication.
+			Default: None
 	"""
 
 	ConfigDefaults = {
 		'bootstrap_servers': 'localhost:9092',
 		'compression_type': '',
+		'security_protocol': 'PLAINTEXT',
+		'sasl_mechanism': 'PLAIN',
+		'sasl_plain_username': '',
+		'sasl_plain_password': '',
 	}
 
 
@@ -51,6 +63,10 @@ class KafkaConnection(Connection):
 			loop=self.Loop,
 			bootstrap_servers=self.get_bootstrap_servers(),
 			compression_type=self.get_compression(),
+			security_protocol=self.Config.get('security_protocol'),
+			sasl_mechanism=self.Config.get('sasl_mechanism'),
+			sasl_plain_username=self.Config.get('sasl_plain_username') or None,
+			sasl_plain_password=self.Config.get('sasl_plain_password') or None,
 			**kwargs
 		)
 		return producer
@@ -62,6 +78,10 @@ class KafkaConnection(Connection):
 			loop=self.Loop,
 			bootstrap_servers=self.get_bootstrap_servers(),
 			enable_auto_commit=False,
+			security_protocol=self.Config.get('security_protocol'),
+			sasl_mechanism=self.Config.get('sasl_mechanism'),
+			sasl_plain_username=self.Config.get('sasl_plain_username') or None,
+			sasl_plain_password=self.Config.get('sasl_plain_password') or None,
 			**kwargs
 		)
 		return consumer

--- a/bspump/kafka/sink.py
+++ b/bspump/kafka/sink.py
@@ -74,10 +74,6 @@ class KafkaSink(Sink):
 		"enable_idempotency": "",
 		"transactional_id": "",
 		"transaction_timeout_ms": "",
-		"sasl_mechanism": "",
-		"sasl_plain_username": "",
-		"sasl_plain_password": "",
-		"security_protocol": "",
 	}
 
 
@@ -108,10 +104,6 @@ class KafkaSink(Sink):
 			"enable_idempotence": bool,
 			"transactional_id": str,
 			"transaction_timeout_ms": int,
-			"sasl_mechanism": str,
-			"sasl_plain_username": str,
-			"sasl_plain_password": str,
-			"security_protocol": str,
 		}
 		self._producer_params = {
 			x: producer_param_definition[x](y)

--- a/bspump/kafka/sink.py
+++ b/bspump/kafka/sink.py
@@ -74,6 +74,10 @@ class KafkaSink(Sink):
 		"enable_idempotency": "",
 		"transactional_id": "",
 		"transaction_timeout_ms": "",
+		"sasl_mechanism": "",
+		"sasl_plain_username": "",
+		"sasl_plain_password": "",
+		"security_protocol": "",
 	}
 
 
@@ -103,7 +107,11 @@ class KafkaSink(Sink):
 			"connections_max_idle_ms": int,
 			"enable_idempotence": bool,
 			"transactional_id": str,
-			"transaction_timeout_ms": int
+			"transaction_timeout_ms": int,
+			"sasl_mechanism": str,
+			"sasl_plain_username": str,
+			"sasl_plain_password": str,
+			"security_protocol": str,
 		}
 		self._producer_params = {
 			x: producer_param_definition[x](y)

--- a/bspump/kafka/source.py
+++ b/bspump/kafka/source.py
@@ -64,11 +64,6 @@ class KafkaSource(Source):
 
 		"event_block_size": 1000,  # The number of lines after which the main method enters the idle state to allow other operations to perform their tasks
 		"event_idle_time": 0.01,  # The time for which the main method enters the idle state (see above)
-
-		"sasl_mechanism": "",
-		"sasl_plain_username": "",
-		"sasl_plain_password": "",
-		"security_protocol": "",
 	}
 
 	def __init__(self, app, pipeline, connection, id=None, config=None):
@@ -110,22 +105,6 @@ class KafkaSource(Source):
 		v = self.Config.get('request_timeout_ms')
 		if v != "":
 			consumer_params['request_timeout_ms'] = int(v)
-
-		v = self.Config.get('sasl_mechanism')
-		if v != "":
-			consumer_params['sasl_mechanism'] = v
-
-		v = self.Config.get('sasl_plain_username')
-		if v != "":
-			consumer_params['sasl_plain_username'] = v
-
-		v = self.Config.get('sasl_plain_password')
-		if v != "":
-			consumer_params['sasl_plain_password'] = v
-
-		v = self.Config.get('security_protocol')
-		if v != "":
-			consumer_params['security_protocol'] = v
 
 		self.MaxRecords = self.Config.get('max_records')
 

--- a/bspump/kafka/source.py
+++ b/bspump/kafka/source.py
@@ -64,6 +64,11 @@ class KafkaSource(Source):
 
 		"event_block_size": 1000,  # The number of lines after which the main method enters the idle state to allow other operations to perform their tasks
 		"event_idle_time": 0.01,  # The time for which the main method enters the idle state (see above)
+
+		"sasl_mechanism": "",
+		"sasl_plain_username": "",
+		"sasl_plain_password": "",
+		"security_protocol": "",
 	}
 
 	def __init__(self, app, pipeline, connection, id=None, config=None):
@@ -105,6 +110,22 @@ class KafkaSource(Source):
 		v = self.Config.get('request_timeout_ms')
 		if v != "":
 			consumer_params['request_timeout_ms'] = int(v)
+
+		v = self.Config.get('sasl_mechanism')
+		if v != "":
+			consumer_params['sasl_mechanism'] = v
+
+		v = self.Config.get('sasl_plain_username')
+		if v != "":
+			consumer_params['sasl_plain_username'] = v
+
+		v = self.Config.get('sasl_plain_password')
+		if v != "":
+			consumer_params['sasl_plain_password'] = v
+
+		v = self.Config.get('security_protocol')
+		if v != "":
+			consumer_params['security_protocol'] = v
 
 		self.MaxRecords = self.Config.get('max_records')
 


### PR DESCRIPTION
This change extends bspump to pass `SASL` mechanism of customer choise to both `KafkaSource` and `KafkaSink`. Either `GSSAPI`, `SCRAM-SHA-256` and `SCRAM-SHA-512` and their credentials.

For `SCRAM` there is one dependency - before final merge - to `aiokafka` upstream
```
pip install https://github.com/SukiCZ/aiokafka/archive/kafka_scram.zip
```
See related PR: https://github.com/aio-libs/aiokafka/pull/588 - only blocker is the fact integration tests are not complete.
