### PR TITLE
Removal of the ABC abstractmethod

### DIFF
--- a/bspump/abc/anomaly.py
+++ b/bspump/abc/anomaly.py
@@ -1,6 +1,3 @@
-import abc
-
-
 class Anomaly(dict):
 	"""
 	Anomaly is an abstract class to be overriden for a specific anomaly and its type.
@@ -18,10 +15,9 @@ class Anomaly(dict):
 		self["D"] = self["ts_end"] - self["@timestamp"]
 		self["status"] = "closed"
 
-	@abc.abstractmethod
 	async def on_tick(self, current_time):
 		"""
 		Implement to perform operations on the anomaly, f. e. close.
 		:param current_time:
 		"""
-		pass
+		raise NotImplementedError()

--- a/bspump/abc/generator.py
+++ b/bspump/abc/generator.py
@@ -1,5 +1,3 @@
-import abc
-
 from .processor import ProcessorBase
 
 
@@ -60,6 +58,6 @@ class Generator(ProcessorBase):
 		)
 		return None
 
-	@abc.abstractmethod
+
 	async def generate(self, context, event, depth):
 		raise NotImplementedError()

--- a/bspump/abc/lookup.py
+++ b/bspump/abc/lookup.py
@@ -1,4 +1,3 @@
-import abc
 import asyncio
 import collections.abc
 import json
@@ -17,7 +16,7 @@ L = logging.getLogger(__name__)
 ###
 
 
-class Lookup(abc.ABC, asab.ConfigObject):
+class Lookup(asab.ConfigObject):
 	"""
 	Lookups serve for fast data searching in lists of key-value type. They can subsequently be localized and used in pipeline objects (processors and the like). Each lookup requires a statically or dynamically created value list.
 
@@ -75,7 +74,6 @@ class Lookup(abc.ABC, asab.ConfigObject):
 			self.PubSub.publish("bspump.Lookup.changed!")
 
 
-	@abc.abstractmethod
 	async def load(self) -> bool:
 		"""
 		Return True is lookup has been changed.
@@ -88,7 +86,8 @@ class Lookup(abc.ABC, asab.ConfigObject):
 			self.set(bspump.load_json_file('./examples/data/country_names.json'))
 			return True
 		"""
-		pass
+		raise NotImplementedError("Lookup '{}' serialize() method not implemented".format(self.Id))
+
 
 	# Serialization
 
@@ -222,9 +221,8 @@ class AsyncLookupMixin(Lookup):
 	respective that require a connection to resource server such as SQL etc.
 	"""
 
-	@abc.abstractmethod
 	async def get(self, key):
-		pass
+		raise NotImplementedError()
 
 
 class DictionaryLookup(MappingLookup):

--- a/bspump/abc/processor.py
+++ b/bspump/abc/processor.py
@@ -1,8 +1,7 @@
-import abc
 import asab
 
 
-class ProcessorBase(abc.ABC, asab.ConfigObject):
+class ProcessorBase(asab.ConfigObject):
 
 
 	def __init__(self, app, pipeline, id=None, config=None):
@@ -30,7 +29,6 @@ class ProcessorBase(abc.ABC, asab.ConfigObject):
 			return cls(app, pipeline, id=newid, config=config)
 
 
-	@abc.abstractmethod
 	def process(self, context, event):
 		raise NotImplementedError()
 

--- a/bspump/abc/source.py
+++ b/bspump/abc/source.py
@@ -1,4 +1,3 @@
-import abc
 import logging
 import asyncio
 import concurrent.futures
@@ -8,7 +7,7 @@ from asab import ConfigObject
 L = logging.getLogger(__name__)
 
 
-class Source(abc.ABC, ConfigObject):
+class Source(ConfigObject):
 
 	"""
 Each source represent a coroutine/Future/Task that is running in the context of the main loop.
@@ -74,7 +73,6 @@ It is acomplished by `await self.Pipeline.ready()` call.
 		self.start(loop)
 
 
-	@abc.abstractmethod
 	async def main(self):
 		raise NotImplementedError()
 
@@ -209,9 +207,9 @@ class TriggerSource(Source):
 				trigger.done(self)
 
 
-	@abc.abstractmethod
 	async def cycle(self, *args, **kwags):
 		raise NotImplementedError()
+
 
 	def rest_get(self):
 		result = super().rest_get()

--- a/bspump/common/time.py
+++ b/bspump/common/time.py
@@ -1,4 +1,3 @@
-import abc
 import datetime
 import logging
 
@@ -36,7 +35,6 @@ class TimeZoneNormalizer(bspump.Processor):
 		return local_time.astimezone(pytz.utc)
 
 
-	@abc.abstractmethod
 	def process(self, context, event):
 		"""
 		Abstract method to process the event. Must be customized.

--- a/bspump/common/transfr.py
+++ b/bspump/common/transfr.py
@@ -1,4 +1,3 @@
-import abc
 import collections.abc
 
 from ..abc.processor import Processor
@@ -13,9 +12,8 @@ class MappingTransformator(Processor):
 		self.Default = None
 
 
-	@abc.abstractmethod
 	def build(self, app):
-		return {}
+		raise NotImplementedError()
 
 
 	def _map(self, item):

--- a/bspump/file/fileabcsource.py
+++ b/bspump/file/fileabcsource.py
@@ -1,4 +1,3 @@
-import abc
 import asyncio
 import logging
 import os
@@ -198,7 +197,6 @@ class FileABCSource(TriggerSource):
 			await asyncio.sleep(self.EventIdleTime)
 			self.LinesCounter = 0
 
-	@abc.abstractmethod
 	async def read(self, filename, f):
 		'''
 		Override this method to implement your File Source.

--- a/bspump/http/client/abcsource.py
+++ b/bspump/http/client/abcsource.py
@@ -1,4 +1,3 @@
-import abc
 import re
 import logging
 import asyncio
@@ -89,7 +88,6 @@ class HTTPABCClientSource(TriggerSource):
 				raise aiohttp.ClientError("{}, url='{}'".format(e, self.URL))
 
 
-	@abc.abstractmethod
 	async def read(self, response):
 		'''
 		Override this method to implement your HTTP Source.

--- a/bspump/ipc/protocol.py
+++ b/bspump/ipc/protocol.py
@@ -1,7 +1,5 @@
-import abc
 
-
-class SourceProtocolABC(abc.ABC):
+class SourceProtocolABC(object):
 	'''
 	Source protocol is a handler class, that basically gets the socket (in reader)
 	and extract the payload from it in a way that is conformant to expected protocol.
@@ -13,9 +11,8 @@ class SourceProtocolABC(abc.ABC):
 	def __init__(self, source, app, pipeline, config):
 		pass
 
-	@abc.abstractmethod
 	async def inbound(self, source, reader, context):
-		pass
+		raise NotImplementedError()
 
 
 class LineSourceProtocol(SourceProtocolABC):

--- a/bspump/lookup/index.py
+++ b/bspump/lookup/index.py
@@ -1,4 +1,3 @@
-import abc
 import logging
 
 import numpy as np
@@ -10,7 +9,7 @@ L = logging.getLogger(__name__)
 ###
 
 
-class Index(abc.ABC):
+class Index(object):
 	def __init__(self, id=None):
 		super().__init__()
 		self.Id = id if id is not None else self.__class__.__name__
@@ -25,9 +24,8 @@ class Index(abc.ABC):
 			'class': self.__class__.__name__,
 		}
 
-	@abc.abstractmethod
 	def search(self, *args) -> set:
-		pass
+		raise NotImplementedError()
 
 
 

--- a/bspump/model/model.py
+++ b/bspump/model/model.py
@@ -1,4 +1,3 @@
-import abc
 import logging
 import json
 
@@ -11,7 +10,7 @@ L = logging.getLogger(__name__)
 ###
 
 
-class Model(abc.ABC, asab.ConfigObject):
+class Model(asab.ConfigObject):
 	'''
 		Generic `Model` object. Loads trained model and parameters.
 
@@ -32,12 +31,11 @@ class Model(abc.ABC, asab.ConfigObject):
 		self.Loop = app.Loop
 
 
-	@abc.abstractmethod
 	def load_model_from_file(self):
 		'''
 		Load model from file.
 		'''
-		pass
+		raise NotImplementedError()
 
 
 	def load_parameters_from_file(self):
@@ -54,7 +52,7 @@ class Model(abc.ABC, asab.ConfigObject):
 		'''
 		pass
 
-	@abc.abstractmethod
+
 	def transform(self, *args):
 		'''
 		Method used to transform data for model input.
@@ -62,7 +60,6 @@ class Model(abc.ABC, asab.ConfigObject):
 		raise NotImplementedError()
 
 
-	@abc.abstractmethod
 	def predict(self, *args):
 		'''
 		Method uses model to predict value from sample.


### PR DESCRIPTION
... because of the unnecessary overhead in the processing that has been discovered in one of the recent profiling sessions.