### PR TITLE
Enabling configuration of "no decoding" for LineSourceProtocol

### DIFF
--- a/bspump/ipc/protocol.py
+++ b/bspump/ipc/protocol.py
@@ -31,12 +31,12 @@ class LineSourceProtocol(SourceProtocolABC):
 
 		# Line decoder
 		decode_codec = config['decode']
-		if len(decode_codec) > 0:
+		if decode_codec == "bytes":
+			self.Codec = None
+			self.LineDecoder = self._line_bytes_decoder
+		else:
 			self.Codec = codecs.lookup(decode_codec)
 			self.LineDecoder = self._line_codec_decoder
-		else:
-			self.Codec = None
-			self.LineDecoder = self._line_none_decoder
 
 
 	async def handle(self, source, stream, context):
@@ -93,5 +93,5 @@ class LineSourceProtocol(SourceProtocolABC):
 		)
 		return line
 
-	def _line_none_decoder(self, line_bytes):
-			return line_bytes
+	def _line_bytes_decoder(self, line_bytes):
+		return line_bytes

--- a/bspump/ipc/stream_server_source.py
+++ b/bspump/ipc/stream_server_source.py
@@ -19,8 +19,12 @@ class StreamServerSource(Source):
 
 	ConfigDefaults = {
 		'address': '127.0.0.1 8888',  # IPv4, IPv6 or unix socket path
-		'backlog': ''
+		'backlog': '',
 		# Specify 'cert' or 'key' to enable SSL / TLS mode
+
+		# An encoding a line is going to be decoded from
+		# - Pass '' (empty string) to prevent decoding
+		'decode': 'utf-8',
 	}
 
 	def __init__(self, app, pipeline, id=None, config=None, protocol_class=LineSourceProtocol):
@@ -38,7 +42,7 @@ class StreamServerSource(Source):
 		self.AcceptingSockets = []
 		self.ConnectedClients = set()  # Set of active _client_connected_task()
 
-		self.Protocol = protocol_class(app, pipeline, config)
+		self.Protocol = protocol_class(app, pipeline, config=self.Config)
 
 		app.PubSub.subscribe("Application.tick!", self._on_tick)
 


### PR DESCRIPTION
This feature is at the same time a fix for services that consume lines but don't wish to decode them into a string object.
Such services typically have KafkaSink at the end of the pipeline, that expects the _event_ to be _bytes_. In such case a pipeline shall be built as follows:


```
# Build the pipeline
self.build(
	bspump.ipc.StreamServerSource(app, self, config={
		'decode': '',
	}),
	...
)
```