### PR TITLE
Fix streamserversource

### DIFF
--- a/bspump/ipc/stream_server_source.py
+++ b/bspump/ipc/stream_server_source.py
@@ -102,7 +102,7 @@ class StreamServerSource(Source):
 
 	async def main(self):
 		if len(self.AcceptingSockets) == 0:
-			L.warning("No listening socket configured")
+			L.error("No listening socket configured")
 			return
 
 		await asyncio.gather(

--- a/bspump/ipc/stream_server_source.py
+++ b/bspump/ipc/stream_server_source.py
@@ -73,8 +73,11 @@ class StreamServerSource(Source):
 						s.listen()
 					else:
 						s.listen(int(backlog))
-						s.setblocking(False)
-						self.AcceptingSockets.append(s)
+
+					s.setblocking(False)
+					self.AcceptingSockets.append(s)
+
+
 			else:
 				self.Socket = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
 				self.Socket.setblocking(False)

--- a/examples/bspump-ipc-tcp-source.py
+++ b/examples/bspump-ipc-tcp-source.py
@@ -26,7 +26,7 @@ class EchoPipeline(bspump.Pipeline):
 	def __init__(self, app, pipeline_id):
 		super().__init__(app, pipeline_id)
 		self.build(
-			bspump.ipc.StreamServerSource(app, self, config={'address': '0.0.0.0 8083'}),
+			bspump.ipc.StreamServerSource(app, self, config={'address': '127.0.0.1:8083'}),
 			EchoSink(app, self)
 		)
 


### PR DESCRIPTION
Btw I do not know why the change to ':' instead of ' ' was originaly requested, but it is misaligned with other components now, for example StreamClientSink still uses the ' ' to separate.