### PR TITLE
Migrate KafkaTopicInitializer to confluent-kafka

### DIFF
--- a/bspump/kafka/__init__.py
+++ b/bspump/kafka/__init__.py
@@ -2,10 +2,12 @@ from .connection import KafkaConnection
 from .source import KafkaSource
 from .sink import KafkaSink
 from .keyfilter import KafkaKeyFilter
+from.topic_initializer import KafkaTopicInitializer
 
 __all__ = [
 	"KafkaConnection",
 	"KafkaSource",
 	"KafkaSink",
 	"KafkaKeyFilter",
+	"KafkaTopicInitializer",
 ]

--- a/bspump/kafka/__init__.py
+++ b/bspump/kafka/__init__.py
@@ -2,7 +2,7 @@ from .connection import KafkaConnection
 from .source import KafkaSource
 from .sink import KafkaSink
 from .keyfilter import KafkaKeyFilter
-from.topic_initializer import KafkaTopicInitializer
+from .topic_initializer import KafkaTopicInitializer
 
 __all__ = [
 	"KafkaConnection",

--- a/bspump/kafka/topic_initializer.py
+++ b/bspump/kafka/topic_initializer.py
@@ -228,7 +228,7 @@ class KafkaTopicInitializer(asab.ConfigObject):
 			L.log(
 				asab.LOG_NOTICE,
 				"Kafka topics created",
-				struct_data={"topics": [topic.name for topic in missing_topics]}
+				struct_data={"topics": ", ".join(topic.name for topic in missing_topics)}
 			)
 
 		except Exception as e:

--- a/bspump/kafka/topic_initializer.py
+++ b/bspump/kafka/topic_initializer.py
@@ -4,7 +4,7 @@ import logging
 import re
 import typing
 
-import kafka.admin
+import confluent_kafka.admin
 
 import asab
 import bspump
@@ -153,7 +153,7 @@ class KafkaTopicInitializer(asab.ConfigObject):
 				topic["num_partitions"] = int(self.Config.get("num_partitions_default"))
 			if "replication_factor" not in topic:
 				topic["replication_factor"] = int(self.Config.get("replication_factor_default"))
-			self.RequiredTopics[topic["name"]] = kafka.admin.NewTopic(**topic)
+			self.RequiredTopics[topic["name"]] = confluent_kafka.admin.NewTopic(**topic)
 
 	def include_topics_from_config(self, config_object):
 		# Every kafka topic needs to have: name, num_partitions and replication_factor
@@ -177,7 +177,7 @@ class KafkaTopicInitializer(asab.ConfigObject):
 
 		# Create topic objects
 		for name in topic_names:
-			self.RequiredTopics[name] = kafka.admin.NewTopic(
+			self.RequiredTopics[name] = confluent_kafka.admin.NewTopic(
 				name,
 				num_partitions,
 				replication_factor,
@@ -185,7 +185,7 @@ class KafkaTopicInitializer(asab.ConfigObject):
 			)
 
 	def fetch_existing_topics(self):
-		admin_client = kafka.admin.KafkaAdminClient(
+		admin_client = confluent_kafka.admin.KafkaAdminClient(
 			bootstrap_servers=self.BootstrapServers,
 			client_id=self.ClientId
 		)
@@ -223,7 +223,7 @@ class KafkaTopicInitializer(asab.ConfigObject):
 		admin_client = None
 
 		try:
-			admin_client = kafka.admin.KafkaAdminClient(
+			admin_client = confluent_kafka.admin.KafkaAdminClient(
 				bootstrap_servers=self.BootstrapServers,
 				client_id=self.ClientId
 			)

--- a/bspump/kafka/topic_initializer.py
+++ b/bspump/kafka/topic_initializer.py
@@ -11,13 +11,6 @@ import bspump
 import bspump.abc.sink
 import bspump.abc.source
 
-# Fastkafka module is required only to support including topics from FastKafkaSource/Sink
-# If it is not available, topics from FastKafkaSource/Sink objects will be ignored
-try:
-	import fastkafka
-except ImportError:
-	fastkafka = None
-
 
 #
 
@@ -57,11 +50,8 @@ _TOPIC_CONFIG_OPTIONS = {
 
 def _is_kafka_component(component):
 	if isinstance(component, bspump.kafka.KafkaSource) \
-		   or isinstance(component, bspump.kafka.KafkaSink):
+		or isinstance(component, bspump.kafka.KafkaSink):
 		return True
-	if fastkafka is not None:
-		return isinstance(component, fastkafka.FastKafkaSource) \
-			   or isinstance(component, fastkafka.FastKafkaSink)
 	return False
 
 

--- a/examples/bspump-kafka-topic-initializer.py
+++ b/examples/bspump-kafka-topic-initializer.py
@@ -1,5 +1,6 @@
 import bspump
 from bspump.kafka import KafkaTopicInitializer
+import asab
 
 
 """
@@ -8,6 +9,10 @@ It checks whether those topics exist on configured Kafka server and initializes 
 
 See `examples/data/kafka-topic-config.yml` for an example topic config file.
 """
+
+asab.Config.add_defaults(
+	{"web": {"listen": "0.0.0.0 8080"}}
+)
 
 if __name__ == '__main__':
 	app = bspump.BSPumpApplication()
@@ -31,7 +36,7 @@ if __name__ == '__main__':
 	)
 
 	# Run the topic check step
-	kti.check_and_initialize()
+	kti.initialize_topics()
 
 	# Run your app
 	# app.run()

--- a/examples/bspump-kafka-topic-initializer.py
+++ b/examples/bspump-kafka-topic-initializer.py
@@ -1,6 +1,10 @@
+import asyncio
+import time
+import confluent_kafka.admin
+
 import bspump
-from bspump.kafka import KafkaTopicInitializer
-import asab
+import bspump.kafka
+import bspump.common
 
 
 """
@@ -10,9 +14,6 @@ It checks whether those topics exist on configured Kafka server and initializes 
 See `examples/data/kafka-topic-config.yml` for an example topic config file.
 """
 
-asab.Config.add_defaults(
-	{"web": {"listen": "0.0.0.0 8080"}}
-)
 
 if __name__ == '__main__':
 	app = bspump.BSPumpApplication()
@@ -22,20 +23,43 @@ if __name__ == '__main__':
 	# Create a KafkaConnection
 	svc.add_connection(
 		bspump.kafka.KafkaConnection(
-			app,
-			"KafkaConnection",
+			app, "KafkaConnection",
 			config={"bootstrap_servers": "localhost:9092"}
 		)
 	)
 
-	# Pass the KafkaConnection name to KafkaTopicInitializer constructor
-	kti = KafkaTopicInitializer(
-		app,
-		"KafkaConnection",
-		config={"topics_file": "data/kafka-topic-config.yml"}
+	# Build example pipeline
+	pipeline = bspump.Pipeline(app, "SamplePipeline")
+	pipeline.build(
+		bspump.kafka.KafkaSource(app, pipeline, "KafkaConnection", config={
+			"topic": "test_source",
+			"group_id": "test",
+		}),
+		bspump.common.PPrintProcessor(app, pipeline),
+		bspump.kafka.KafkaSink(app, pipeline, "KafkaConnection", config={
+			"topic": "test_sink"
+		}),
 	)
+	svc.add_pipeline(pipeline)
 
-	# Run the topic check step
+	# Pass the KafkaConnection name to KafkaTopicInitializer constructor
+	kti = bspump.kafka.KafkaTopicInitializer(app, "KafkaConnection")
+
+	# Add topics required by pipeline components
+	kti.include_topics(pipeline=pipeline)
+
+	# Add topics from YAML file
+	kti.include_topics(config_file="data/kafka-topic-config.yml")
+
+	# Add topics from dict config
+	kti.include_topics(topic_config={
+		"topic": "new_topic",
+		"num_partitions": 1,
+		"replication_factor": 1,
+		"retention.ms": 3600000,
+	})
+
+	# Check and create missing topics
 	kti.initialize_topics()
 
 	# Run your app

--- a/examples/data/kafka-topic-config.yml
+++ b/examples/data/kafka-topic-config.yml
@@ -1,8 +1,8 @@
-- name: fine_topic
+- topic: fine_topic
   num_partitions: 10
   replication_factor: 1
-  topic_configs:
+  config:
     retention.ms: 60000
-- name: great_topic
+- topic: great_topic
   num_partitions: 1
-  replication_factor: 3
+  replication_factor: 1


### PR DESCRIPTION
- Use `confluent-kafka` instad of `kafka` library
- Remove support for `fastkafka`