### PR TITLE
Fixed that cysimdjson was set to only "21.11b2"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,7 @@ setup(
 		'motor>=2.1.0',
 		'mongoquery>=1.3.6',
 		'pybind11>=2.6.1',
-		'cysimdjson==21.11b2',
+		'cysimdjson>=21.11',
 		'pywinrm>=0.4.1',
 		'pandas>=0.24.2',
 		'xxhash>=1.4.4',


### PR DESCRIPTION
I've encountered an issue when trying to install bspump through pip on Mac. Whenever I tried to install it, it would fail on cysimdjson, however when I tried to install cysimdjson on it's own it worked.

As it turns out cysimdjson version 21.11b2 (The version that bspump currently depends on) is not installable on Mac for some reason. But cysimdjson version 21.11 is.

I don't know if there's a reason for using only "21.11b2" but if there's not it should probably be latest.