### PR TITLE
Fill columns and rows in default with None instead of zero

### DIFF
--- a/bspump/matrix/matrix.py
+++ b/bspump/matrix/matrix.py
@@ -148,7 +148,7 @@ class Matrix(abc.ABC, asab.ConfigObject):
 		Override this method to gain control on how a new closed rows are added to the matrix
 		'''
 		current_rows = self.Array.shape[0]
-		self.Array.resize((current_rows + rows,) + self.Array.shape[1:], refcheck=False)
+		self.Array = np.pad(self.Array.copy(), ((0, rows), (0, 0)), 'constant', constant_values=np.nan)
 		self.ClosedRows.extend(current_rows, self.Array.shape[0])
 
 

--- a/bspump/matrix/timewindowmatrix.py
+++ b/bspump/matrix/timewindowmatrix.py
@@ -210,7 +210,8 @@ class TimeWindowMatrix(NamedMatrix):
 		if self.Array.shape[0] == 0:
 			return
 
-		column = np.zeros((self.Array.shape[0], 1,) + self.Array.shape[2:], dtype=self.Array.dtype)
+		column = np.empty((self.Array.shape[0], 1,) + self.Array.shape[2:], dtype=self.Array.dtype)
+		column[:] = np.nan
 		array = self.Array
 		array = np.hstack((array, column))
 		array = np.delete(array, 0, axis=1)

--- a/bspump/matrix/utils/warmingupcount.py
+++ b/bspump/matrix/utils/warmingupcount.py
@@ -5,7 +5,7 @@ import os
 class WarmingUpCount(object):
 	def __init__(self, size):
 		self.DType = 'i8'
-		self.WUC = np.zeros(size, dtype=self.DType)
+		self.WUC = np.empty(size, dtype=self.DType)
 
 
 	def decrease(self, indexes):
@@ -49,7 +49,8 @@ class PersistentWarmingUpCount(WarmingUpCount):
 	def extend(self, size, value):
 		start = self.WUC.shape[0]
 		end = size
-		wuc = np.zeros(self.WUC.shape[0], dtype=self.DType)
+		wuc = np.empty(self.WUC.shape[0], dtype=self.DType)
+		wuc[:] = np.nan
 		wuc[:] = self.WUC[:]
 		wuc.resize(size, refcheck=False)
 		self.WUC = np.memmap(self.Path, dtype=self.DType, mode='w+', shape=wuc.shape)


### PR DESCRIPTION
When added, columns and rows in time window analyzer matrix are in default filled with zeros. This happens also when there are some missing values (e.g., some events won't arrive). This is problematic, because if one analyzes data, values for events which haven't arrive should be None, not zero. The reason is, that some metrics can be zero (e.g., set up success call rate), and if instead of None, there is zero, it provides wrong statistical calculations (e.g., average of set up success call rate for past few hours). The same problem is when the matrix is created, you cannot know if the zero values are because of metric had value zero, or, because it was pre-filled.