### PR TITLE
LDAPSource shouldn't decode bytestring values

### DIFF
--- a/bspump/ldap/source.py
+++ b/bspump/ldap/source.py
@@ -22,7 +22,6 @@ class LDAPSource(TriggerSource):
 		"filter": "(&(objectClass=inetOrgPerson)(cn=*))",
 		"attributes": "dn objectGUID sAMAccountName email givenName sn UserAccountControl",
 		"results_per_page": 1000,
-		"attribute_encoding": "utf-8",
 	}
 
 	def __init__(self, app, pipeline, connection, id=None, config=None):
@@ -33,7 +32,6 @@ class LDAPSource(TriggerSource):
 		self.Base = self.Config.get("base")
 		self.Filter = self.Config.get("filter")
 		self.Attributes = self.Config.get("attributes").split(" ")
-		self.AttributeEncoding = self.Config.get("attribute_encoding")
 		self.ResultsPerPage = self.Config.getint("results_per_page")
 
 	async def cycle(self):

--- a/examples/bspump-ldap-source.py
+++ b/examples/bspump-ldap-source.py
@@ -14,10 +14,16 @@ L = logging.getLogger(__name__)
 
 class NormalizeProcessor(bspump.Processor):
 	def process(self, context, event):
-		if "sAMAccountName" in event:
-			event["username"] = event.pop("sAMAccountName")
-		if "userAccountControl" in event:
-			event["suspended"] = int(event.pop("userAccountControl")) & 2 == 2
+		event_out = {}
+		for k, v in event.items():
+			if k in ("dn", "sAMAccountName", "email", "givenName", "sn"):
+				event_out[k] = k.decode("ascii")
+			elif k in ("createTimestamp", "modifyTimestamp"):
+				event_out[k] = int(k)
+			elif k == "objectGUID":
+				event_out["id"] = k.hex()
+			elif k == "UserAccountControl":
+				event_out["suspended"] = int(event["userAccountControl"]) & 2 == 2
 		return event
 
 


### PR DESCRIPTION
LDAP source output event values are kept as bytestrings. 

Their parsing is left up to the succeeding components.