### PR TITLE
Fix: `Trigger.construct` implementation

### DIFF
--- a/bspump/trigger/opportunistic.py
+++ b/bspump/trigger/opportunistic.py
@@ -38,6 +38,7 @@ class OpportunisticTrigger(Trigger):
 
 	@classmethod
 	def construct(cls, app, definition: dict):
-		newid = definition.get('id')
-		# TODO: fix
-		return cls(app, newid)
+		id = definition.get('id')
+		run_immediately = definition.get('args', {}).get('run_immediately', True)
+		chilldown_period = definition.get('args', {}).get('chilldown_period', 5)
+		return cls(app, id=id, run_immediately=run_immediately, chilldown_period=chilldown_period)

--- a/bspump/trigger/periodic.py
+++ b/bspump/trigger/periodic.py
@@ -17,3 +17,9 @@ class PeriodicTrigger(Trigger):
 
 	async def on_timer(self):
 		self.fire()
+
+	@classmethod
+	def construct(cls, app, definition: dict):
+		id = definition.get('id')
+		interval = definition.get('args', {}).get('interval', 1.0)
+		return cls(app, id=id, interval=interval)

--- a/bspump/trigger/pubsub.py
+++ b/bspump/trigger/pubsub.py
@@ -17,3 +17,10 @@ class PubSubTrigger(Trigger):
 
 	async def on_message(self, message_type):
 		self.fire()
+
+
+	@classmethod
+	def construct(cls, app, definition: dict):
+		id = definition.get('id')
+		message_types = definition.get('args', {}).get('message_types')
+		return cls(app, id=id, message_types=message_types)


### PR DESCRIPTION
Method `Trigger.construct()` was not correctly implemented in `OpportunisticTrigger` and was missing in `PubSubTrigger` and `PeriodicTrigger`. This should fix that.