### PR TITLE
Allow to set urls in [kafka] section + backward compatibility

### DIFF
--- a/bspump/kafka/connection.py
+++ b/bspump/kafka/connection.py
@@ -38,9 +38,9 @@ class KafkaConnection(Connection):
 	def __init__(self, app, id=None, config=None):
 		super().__init__(app, id=id, config=config)
 
-		# same parameters from [kafka] section take precedence
-		if "kafka" in asab.Config:
-			self.Config.update(asab.Config["kafka"])
+		if self.Config.get("bootstrap_servers") is None:
+			if "kafka" in asab.Config:
+				self.Config.update(asab.Config["kafka"])
 
 		if self.Config.get("bootstrap_servers") is None:
 			raise RuntimeError("No Kafka URL has been provided.")

--- a/bspump/kafka/connection.py
+++ b/bspump/kafka/connection.py
@@ -43,4 +43,4 @@ class KafkaConnection(Connection):
 				self.Config.update(asab.Config["kafka"])
 
 		if self.Config.get("bootstrap_servers") is None:
-			raise RuntimeError("No Kafka URL has been provided.")
+			raise RuntimeError("Missing 'bootstrap_servers' in Kafka connection configuration.")

--- a/bspump/kafka/connection.py
+++ b/bspump/kafka/connection.py
@@ -1,5 +1,7 @@
 import logging
 
+import asab
+
 from ..abc.connection import Connection
 
 #
@@ -35,3 +37,10 @@ class KafkaConnection(Connection):
 
 	def __init__(self, app, id=None, config=None):
 		super().__init__(app, id=id, config=config)
+
+		# same parameters from [kafka] section take precedence
+		if "kafka" in asab.Config:
+			self.Config.update(asab.Config["kafka"])
+
+		if self.Config.get("bootstrap_servers") is None:
+			raise RuntimeError("No Kafka URL has been provided.")


### PR DESCRIPTION
Both sections can be used to provide urls:

```
[connection:KafkaConnection]
bootstrap_servers=localhost:9092,localhost:9092,localhost:9092
```
or

```
[kafka]
bootstrap_servers=localhost:9092,localhost:9092,localhost:9092
```

`[connection:KafkaConnection]` takes precedence