### PR TITLE
Fix of the unhandled exception in IPC when the application exits

### DIFF
--- a/bspump/ipc/stream.py
+++ b/bspump/ipc/stream.py
@@ -2,6 +2,8 @@ import asyncio
 import logging
 import ssl
 
+import asab
+
 #
 
 L = logging.getLogger(__name__)
@@ -40,13 +42,18 @@ class Stream(object):
 		Handle outbound direction
 		'''
 		while True:
+
 			try:
 				data = await self.OutboundQueue.get()
-			except RuntimeError:
+
+			except RuntimeError as e:
 				# Event loop has been closed during .get() call likely b/c of the application exit
+				L.log(asab.LOG_NOTICE, "Outbound queue for Stream has been closed: '{}'.".format(e))
 				break
+
 			if data is None:
 				break
+
 			await self.Loop.sock_sendall(self.Socket, data)
 
 
@@ -148,11 +155,15 @@ class TLSStream(object):
 		Handle outbound direction
 		'''
 		while True:
+
 			try:
 				data = await self.OutboundQueue.get()
-			except RuntimeError:
+
+			except RuntimeError as e:
 				# Event loop has been closed during .get() call likely b/c of the application exit
+				L.log(asab.LOG_NOTICE, "Outbound queue for Stream has been closed: '{}'.".format(e))
 				break
+
 			if data is None:
 				break
 

--- a/bspump/ipc/stream.py
+++ b/bspump/ipc/stream.py
@@ -40,7 +40,11 @@ class Stream(object):
 		Handle outbound direction
 		'''
 		while True:
-			data = await self.OutboundQueue.get()
+			try:
+				data = await self.OutboundQueue.get()
+			except RuntimeError:
+				# Event loop has been closed during .get() call likely b/c of the application exit
+				break
 			if data is None:
 				break
 			await self.Loop.sock_sendall(self.Socket, data)
@@ -144,7 +148,11 @@ class TLSStream(object):
 		Handle outbound direction
 		'''
 		while True:
-			data = await self.OutboundQueue.get()
+			try:
+				data = await self.OutboundQueue.get()
+			except RuntimeError:
+				# Event loop has been closed during .get() call likely b/c of the application exit
+				break
 			if data is None:
 				break
 

--- a/bspump/ipc/stream.py
+++ b/bspump/ipc/stream.py
@@ -48,7 +48,7 @@ class Stream(object):
 
 			except RuntimeError as e:
 				# Event loop has been closed during .get() call likely b/c of the application exit
-				L.log(asab.LOG_NOTICE, "Outbound queue for Stream has been closed: '{}'.".format(e))
+				L.warning("Outbound queue for Stream has been closed: '{}'.".format(e))
 				break
 
 			if data is None:
@@ -161,7 +161,7 @@ class TLSStream(object):
 
 			except RuntimeError as e:
 				# Event loop has been closed during .get() call likely b/c of the application exit
-				L.log(asab.LOG_NOTICE, "Outbound queue for Stream has been closed: '{}'.".format(e))
+				L.warning("Outbound queue for Stream has been closed: '{}'.".format(e))
 				break
 
 			if data is None:


### PR DESCRIPTION
Fixing:

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/bspump/ipc/stream.py", line 43, in outbound
    data = await self.OutboundQueue.get()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/asyncio/queues.py", line 160, in get
    getter.cancel()  # Just in case getter is not done yet.
    ^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/asyncio/base_events.py", line 761, in call_soon
    self._check_closed()
  File "/usr/local/lib/python3.11/asyncio/base_events.py", line 519, in _check_closed
    raise RuntimeError('Event loop is closed')
RuntimeError: Event loop is closed
```