### PR TITLE
Line Source Protocol replaces malformed data with backslash escape sequence

### DIFF
--- a/bspump/ipc/datagram.py
+++ b/bspump/ipc/datagram.py
@@ -81,7 +81,14 @@ class DatagramSource(Source):
 				try:
 					addrinfo = socket.getaddrinfo(addr[0], addr[1], family=socket.AF_UNSPEC, type=socket.SOCK_DGRAM, flags=socket.AI_PASSIVE)
 				except Exception as e:
-					L.error("Failed to open socket: {}".format(e), struct_data={'host': addr[0], 'port': addr[1]})
+					L.error(
+						"Failed to open socket: {}".format(e),
+						struct_data={
+							'id': self.Id,
+							'host': addr[0],
+							'port': addr[1]
+						}
+					)
 					continue
 
 				for family, socktype, proto, canonname, sockaddr in addrinfo:
@@ -96,11 +103,20 @@ class DatagramSource(Source):
 					try:
 						s.bind(sockaddr)
 					except OSError as e:
-						L.warning("Failed to start listening: {}".format(e), struct_data={'host': sockaddr[0], 'port': sockaddr[1]})
+						L.warning("Failed to start listening: {}".format(e), struct_data={'id': self.Id, 'host': sockaddr[0], 'port': sockaddr[1]})
 						continue
 
 					self.AcceptingSockets.append(s)
-					L.log(asab.LOG_NOTICE, "Listening on UDP", struct_data={'host': sockaddr[0], 'port': sockaddr[1], 'family': inet_family_names.get(family, "???")})
+					L.log(
+						asab.LOG_NOTICE,
+						"Listening on UDP",
+						struct_data={
+							'id': self.Id,
+							'host': sockaddr[0],
+							'port': sockaddr[1],
+							'family': inet_family_names.get(family, "???")
+						}
+					)
 
 
 		super().start(loop)
@@ -112,8 +128,11 @@ class DatagramSource(Source):
 				# We should remove the UNIX socket when the the collector is not running
 				try:
 					os.unlink(s.getsockname())
-				except Exception:
-					L.exception("Error when removing socket file")
+				except Exception as err:
+					L.exception(
+						"Error when removing socket file: '{}'".format(err),
+						struct_data={"id": self.Id}
+					)
 
 		# The main() will be canceled in the parent class
 		await super().stop()
@@ -141,8 +160,13 @@ class DatagramSource(Source):
 			except asyncio.CancelledError:
 				break
 
-			except Exception:
-				L.exception("Error in datagram source.")
+			except Exception as err:
+				L.exception(
+					"Error in datagram source: '{}'".format(err),
+					struct_data={
+						"id": self.Id
+					}
+				)
 				raise
 
 
@@ -162,8 +186,13 @@ class DatagramSource(Source):
 			except asyncio.CancelledError:
 				break
 
-			except Exception:
-				L.exception("Error in datagram source.")
+			except Exception as err:
+				L.exception(
+					"Error in datagram source: '{}'".format(err),
+					struct_data={
+						"id": self.Id
+					}
+				)
 				raise
 
 

--- a/bspump/ipc/datagram.py
+++ b/bspump/ipc/datagram.py
@@ -62,7 +62,7 @@ class DatagramSource(Source):
 					if stat.S_ISSOCK(usstat.st_mode):
 						os.unlink(addrline)
 					else:
-						L.warn("Cannot listen on UNIX socket, path is already occupied", struct_data={'path': addrline})
+						L.warning("Cannot listen on UNIX socket, path is already occupied", struct_data={'path': addrline})
 						continue
 
 				s = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)

--- a/bspump/ipc/protocol.py
+++ b/bspump/ipc/protocol.py
@@ -1,4 +1,7 @@
 import codecs
+import logging
+
+L = logging.getLogger(__name__)
 
 
 class SourceProtocolABC(object):
@@ -93,10 +96,13 @@ class LineSourceProtocol(SourceProtocolABC):
 
 
 	def _line_codec_decoder(self, line_bytes):
-		line, _ = self.Codec.decode(
-			line_bytes
-		)
-		return line
+		try:
+			line, _ = self.Codec.decode(line_bytes)
+		except UnicodeDecodeError as err:
+			L.warning("Cannot decode line, replacing malformed data with backslash escape sequence: {}".format(err))
+			line, _ = self.Codec.decode(line_bytes, errors="backslashreplace")
+		finally:
+			return line
 
 	def _line_bytes_decoder(self, line_bytes):
 		return line_bytes

--- a/bspump/ipc/protocol.py
+++ b/bspump/ipc/protocol.py
@@ -98,8 +98,7 @@ class LineSourceProtocol(SourceProtocolABC):
 	def _line_codec_decoder(self, line_bytes):
 		try:
 			line, _ = self.Codec.decode(line_bytes)
-		except UnicodeDecodeError as err:
-			L.warning("Cannot decode line, replacing malformed data with backslash escape sequence: {}".format(err))
+		except UnicodeDecodeError:
 			line, _ = self.Codec.decode(line_bytes, errors="backslashreplace")
 		finally:
 			return line

--- a/bspump/ipc/stream_server_source.py
+++ b/bspump/ipc/stream_server_source.py
@@ -70,7 +70,7 @@ class StreamServerSource(Source):
 					if stat.S_ISSOCK(usstat.st_mode):
 						os.unlink(addrline)
 					else:
-						L.warn("Cannot listen on UNIX socket, path is already occupied", struct_data={'path': addrline})
+						L.warning("Cannot listen on UNIX socket, path is already occupied", struct_data={'path': addrline})
 						continue
 
 				s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)


### PR DESCRIPTION
- When decoding with the provided codec fails, malformed data is replaced with backslash escape sequence with a warning:
```
10-Sep-2024 13:19:49.188516 WARNING bspump.ipc.protocol Cannot decode line, replacing malformed data with backslash escape sequence: 'utf-8' codec can't decode byte 0xc0 in position 0: invalid start byte
```

- Logging now contains ID of the source in `struct_data` to make debugging much easier in case there are multiple TCP/UDP sources.