### PR TITLE
Fix LDAP error handling and logging; improve default config

### DIFF
--- a/bspump/ldap/connection.py
+++ b/bspump/ldap/connection.py
@@ -35,9 +35,10 @@ class LDAPConnection(Connection):
 	"""
 
 	ConfigDefaults = {
+		# Either specify "uri", OR "host" (and "port", if non-standard)
+		"uri": "",
 		"host": "localhost",
 		"port": 0,  # = use the default 389 for non-secure and 636 for secure connection
-		"uri": "",
 		"username": "cn=admin,dc=example,dc=org",
 		"password": "admin",
 

--- a/bspump/ldap/connection.py
+++ b/bspump/ldap/connection.py
@@ -81,9 +81,11 @@ class LDAPConnection(Connection):
 
 		try:
 			client.simple_bind_s(self.Config.get("username"), self.Config.get("password"))
-			yield client
 		except Exception as e:
-			L.error("Cannot connect to LDAP server: {}".format(e), exc_info=True, struct_data={"ldap_uri": self.URI})
+			raise RuntimeError("Cannot connect to LDAP server: {}".format(e.__class__.__name__))
+
+		try:
+			yield client
 		finally:
 			client.unbind_s()
 

--- a/bspump/ldap/source.py
+++ b/bspump/ldap/source.py
@@ -20,8 +20,8 @@ class LDAPSource(TriggerSource):
 
 	ConfigDefaults = {
 		"base": "dc=example,dc=org",
-		"filter": "(&(objectClass=inetOrgPerson)(cn=*))",
-		"attributes": "dn objectGUID sAMAccountName email givenName sn UserAccountControl",
+		"filter": "(|(objectClass=organizationalPerson)(objectClass=inetOrgPerson))",  # Retrieve user accounts on most servers
+		"attributes": "sAMAccountName mail givenName sn displayName UserAccountControl",
 		"results_per_page": 1000,
 	}
 

--- a/bspump/ldap/source.py
+++ b/bspump/ldap/source.py
@@ -62,7 +62,13 @@ class LDAPSource(TriggerSource):
 				attrlist=self.Attributes,
 				serverctrls=[paged_results_control],
 			)
-			res_type, res_data, res_msgid, serverctrls = client.result3(msgid)
+			try:
+				res_type, res_data, res_msgid, serverctrls = client.result3(msgid)
+			except Exception as e:
+				L.error("LDAP search failed: {}".format(e.__class__.__name__), struct_data={
+					"base": self.Base, "filter": self.Filter, "err_data": str(e)})
+				return [], None
+
 			for dn, attrs in res_data:
 				if dn is None:
 					# Skip system entries

--- a/bspump/ldap/source.py
+++ b/bspump/ldap/source.py
@@ -74,7 +74,9 @@ class LDAPSource(TriggerSource):
 					# Skip system entries
 					continue
 
-				event = {}
+				# Include distinguished name (DN) attribute
+				event = {"dn": dn}
+
 				# LDAP returns all attributes as lists of bytestrings, e.g.:
 				#   {"sAMAccountName": [b"vhavel"], ...}
 				# Unpack them
@@ -85,6 +87,7 @@ class LDAPSource(TriggerSource):
 						elif len(v) == 1:
 							v = v[0]
 					event[k] = v
+
 				page.append(event)
 
 			for sc in serverctrls:


### PR DESCRIPTION
- Fix connection error handling.
- Do not log traceback unless necessary.
- Improve defaults to minimize configuration.