### PR TITLE
Add check for Kafka source assigment errors + better work with times.

### DIFF
--- a/bspump/kafka/source.py
+++ b/bspump/kafka/source.py
@@ -272,6 +272,9 @@ class KafkaSource(Source):
 
 				self.Buffer = []
 
+				# Make sure the pipeline is ready to receive messages
+				await self.Pipeline.ready()
+
 				for m in messages:
 
 					await self.process(m.value(), context={

--- a/bspump/kafka/source.py
+++ b/bspump/kafka/source.py
@@ -62,7 +62,7 @@ class KafkaSource(Source):
 		# This range provides a balance between responsiveness and resource utilization.
 		# If the total number of partitions is very high and/or if the message production rate is significant, you might need to lean towards the lower end of the recommended range (e.g., 0.5 seconds)
 		# or even slightly below, but not too much to avoid excessive overhead.
-		"poll_interval": 0.5,
+		"poll_interval": 0.3,
 		"buffer_size": 1000,
 		"buffer_timeout": 1.0,
 		"sleep_on_error": 3.0,
@@ -73,7 +73,7 @@ class KafkaSource(Source):
 		"enable.auto.commit": "false",
 
 		"auto.commit.interval.ms": "1000",
-		"auto.offset.reset": "smallest",
+		"auto.offset.reset": "earliest",
 		"group.id": "bspump",
 	}
 
@@ -117,7 +117,7 @@ class KafkaSource(Source):
 		# It is frequent enough to ensure that the consumer remains active, heartbeats are sent regularly,
 		# and messages are fetched in a timely manner. At the same time, it avoids the excessive overhead associated with
 		# very frequent polling.
-		self.PollInterval = float(self.Config.pop("poll_interval", 0.5))
+		self.PollInterval = float(self.Config.pop("poll_interval", 0.3))
 
 		# Size of the buffer of consumed messages
 		self.BufferSize = int(self.Config.pop("buffer_size", 1000))
@@ -329,11 +329,13 @@ class KafkaSource(Source):
 
 			try:
 				# Run the poll loop on a separate thread
+				current_time = self.App.time()
+
 				for _ in range(0, self.ConsumerThreadsSize):
 					storage = {
-						"last_refresh_topic_time": 0,
-						"last_assignment_error_check_time": 0,
-						"last_flush_time": 0,
+						"last_refresh_topic_time": current_time,
+						"last_assignment_error_check_time": current_time,
+						"last_flush_time": current_time,
 					}
 
 					# Create the consumer for the given thread

--- a/bspump/kafka/source.py
+++ b/bspump/kafka/source.py
@@ -325,7 +325,7 @@ class KafkaSource(Source):
 		while self.Running:
 			consumers = []
 			consumer_tasks = []
-			consumer_storage = []
+			consumer_storages = []
 
 			try:
 				# Run the poll loop on a separate thread
@@ -349,7 +349,7 @@ class KafkaSource(Source):
 					c.subscribe(self.Subscribe)
 
 					consumers.append(c)
-					consumer_storage.append(storage)
+					consumer_storages.append(storage)
 					consumer_tasks.append(
 						self.Loop.run_in_executor(self.ThreadPoolExecutor, self.poll_kafka, c, storage)
 					)


### PR DESCRIPTION
This MR adds a check of errors on assignment, that may not be properly propagated to message errors. The consumer is recreated similarly to message errors.

Also, I try to avoid time.time(), but I still need to use self.App.time() - not sure if it is thread safe though, but at least the time function avoids the coroutine calling mechanism of the loop completely. This needs to be tested under high pressure.