### PR TITLE
Fix CSV source for Python 3.11

### DIFF
--- a/bspump/file/fileabcsource.py
+++ b/bspump/file/fileabcsource.py
@@ -169,8 +169,8 @@ class FileABCSource(TriggerSource):
 		# Read and process the file content
 		try:
 			await self.read(filename, f)
-		except Exception as err:
-			L.exception(err)
+		except Exception:
+			L.exception("Cannot read from file.", struct_data={"filename": filename})
 			try:
 				if self.post == "noop":
 					# When we should stop, rename file back to original

--- a/bspump/file/filecsvsource.py
+++ b/bspump/file/filecsvsource.py
@@ -17,7 +17,7 @@ class FileCSVSource(FileABCSource):
 		'dialect': 'excel',
 		'delimiter': ',',
 		'doublequote': True,
-		'escapechar': "",
+		'escapechar': "\n",
 		'lineterminator': os.linesep,
 		'quotechar': '"',
 		'quoting': csv.QUOTE_MINIMAL,

--- a/bspump/file/filecsvsource.py
+++ b/bspump/file/filecsvsource.py
@@ -17,7 +17,7 @@ class FileCSVSource(FileABCSource):
 		'dialect': 'excel',
 		'delimiter': ',',
 		'doublequote': True,
-		'escapechar': "\n",
+		'escapechar': "\\",  # Python >3.11 does not allow empty value
 		'lineterminator': os.linesep,
 		'quotechar': '"',
 		'quoting': csv.QUOTE_MINIMAL,

--- a/bspump/file/globscan.py
+++ b/bspump/file/globscan.py
@@ -24,6 +24,9 @@ else:
 
 
 def _glob_scan(path, gauge, loop, exclude='', include=''):
+	"""
+	Find the first file that was not already processed based on `exclude` and `include` filters.
+	"""
 	if path is None:
 		return None
 	if path == "":

--- a/examples/bspump-csv.py
+++ b/examples/bspump-csv.py
@@ -13,38 +13,48 @@ L = logging.getLogger(__name__)
 ###
 
 
-class SamplePipeline(bspump.Pipeline):
-
+class SampleCSVPipeline(bspump.Pipeline):
 	def __init__(self, app, pipeline_id):
 		super().__init__(app, pipeline_id)
 
-		self.Sink = bspump.file.FileCSVSink(app, self, config={'path': './data/out.csv'})
-
-		self.build(
-			bspump.file.FileCSVSource(
-				app, self, config={'path': './data/sample.csv', 'delimiter': ';', 'post': 'noop'}
-			).on(bspump.trigger.RunOnceTrigger(app)),
-			bspump.common.PPrintProcessor(app, self),
-			self.Sink
+		self.Source = bspump.file.FileCSVSource(
+			app,
+			self,
+			config={
+				"path": "./examples/data/countries.csv",
+				"delimiter": ";",
+				"post": "noop",  # one of 'delete', 'noop' and 'move'
+			},
+		)
+		self.Sink = bspump.file.FileCSVSink(
+			app, self, config={"path": "./examples/data/countries-out.csv"}
 		)
 
+		self.build(
+			self.Source.on(bspump.trigger.RunOnceTrigger(app)),
+			bspump.common.PPrintProcessor(app, self),
+			self.Sink,
+		)
+
+		self.PubSub.subscribe("bspump.file_source.no_files!", self.on_no_files)
 		self.PubSub.subscribe("bspump.pipeline.cycle_end!", self.on_cycle_end)
 
-
 	def on_cycle_end(self, event_name, pipeline):
-		'''
-		This ensures that at the end of the file scan, the target file is closed
-		'''
+		"""
+		This ensures that at the end of the file scan, the target file is closed.
+		"""
 		self.Sink.rotate()
 
+	def on_no_files(self, event_name, pipeline):
+		L.warning("No files found in the selected path.")
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
 	app = bspump.BSPumpApplication()
-
-	svc = app.get_service("bspump.PumpService")
+	svc: bspump.BSPumpService = app.get_service("bspump.PumpService")
 
 	# Construct and register Pipeline
-	pl = SamplePipeline(app, 'SamplePipeline')
-	svc.add_pipeline(pl)
+	pipeline = SampleCSVPipeline(app, "SampleCSVPipeline")
+	svc.add_pipeline(pipeline)
 
 	app.run()

--- a/examples/data/countries.csv
+++ b/examples/data/countries.csv
@@ -1,0 +1,11 @@
+Position;Country Code;Country;Capital
+1;DE;Germany;Berlin
+2;CZ;Czech Republic;Prague
+3;FR;France;Paris
+4;IT;Italy;Rome
+5;ES;Spain;Madrid
+6;PL;Poland;Warsaw
+7;NL;Netherlands;Amsterdam
+8;BE;Belgium;Brussels
+9;SE;Sweden;Stockholm
+10;FI;Finland;Helsinki


### PR DESCRIPTION
As of python3.11, `escapechar` option in `csv.Dialect` is not allowed, see [the docs](https://docs.python.org/3/library/csv.html#csv.Dialect.escapechar). By default, it is set to `None`, but this is not allowed in `asab.Config.ConfigDefaults`. I changed its value to `\` and slightly modified the example.

Moreover, the `read()` was silent to errors. I put them in a exception log.

